### PR TITLE
Add Devvit (Reddit Developer Platform) port

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ go.work.sum
 # env file
 .env
 hnbot
+
+# Claude Code
+.claude

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@ hnbot
 
 # Claude Code
 .claude
+
+# Node
+devvit/node_modules
+devvit/package-lock.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Reddit bot that automatically posts Hacker News front page stories to r/hackernews. It fetches stories from the hnrss.org RSS feed and posts them to Reddit, adding a comment with the HN discussion link for non-HN URLs.
+
+Two implementations exist:
+- **Go version** (`main.go`) - Original implementation using graw library (legacy, blocked by Reddit API changes)
+- **Devvit version** (`devvit/`) - Port to Reddit's Developer Platform (TypeScript)
+
+## Build and Run Commands
+
+### Go Version (Legacy)
+
+```bash
+# Run the bot (requires environment variables)
+REDDIT_SECRET=... REDDIT_PASSWORD=... go run .
+
+# Run tests
+go test ./...
+
+# Run a specific test
+go test -run TestNormalizeURL
+
+# Build binary
+go build -o hnbot .
+```
+
+### Devvit Version
+
+```bash
+cd devvit
+
+# Install dependencies
+npm install
+
+# Login to Devvit
+devvit login
+
+# Test locally on a subreddit
+devvit playtest r/hackernews
+
+# Upload to Reddit
+devvit upload
+
+# Install on subreddit
+devvit install r/hackernews
+```
+
+## Environment Variables (Go Version Only)
+
+- `REDDIT_SECRET` - Reddit API client secret
+- `REDDIT_PASSWORD` - Reddit account password for u/hnmod
+
+The Devvit version handles authentication automatically through the platform.
+
+## Architecture
+
+Both versions share the same logic flow:
+
+1. **Feed fetching** (`getFeed`) - Fetches HN front page stories from hnrss.org RSS feed with filters (100+ points, 10+ comments)
+2. **Feed processing** (`processFeed`) - Iterates through feed items, checks for duplicates, posts new stories
+3. **Duplicate detection** (`isDuplicate`, `getExistingPosts`) - Fetches recent posts from r/hackernews (new/hot/top) and compares URLs and titles
+4. **Posting** (`postNew`) - Creates Reddit link post; for non-HN URLs, adds a comment linking to the HN discussion
+
+### Go Version Structure
+
+Single-file application (`main.go`) using graw library for Reddit API.
+
+### Devvit Version Structure
+
+```
+devvit/src/
+├── main.ts           # Entry point, Devvit config, triggers
+├── constants.ts      # Configuration constants
+├── types.ts          # TypeScript interfaces
+├── url.ts            # URL normalization functions
+├── duplicate.ts      # Duplicate detection logic
+├── feed.ts           # RSS feed fetching and parsing
+├── posts.ts          # Reddit post operations
+└── scheduler.ts      # Scheduled job and feed processing
+```
+
+The Devvit version uses:
+- Built-in scheduler with cron (`*/15 * * * *`) instead of GitHub Actions
+- `fetch()` API for RSS instead of gofeed library
+- Devvit Reddit API (`context.reddit`) instead of graw library
+
+## Key Constants
+
+- `HN_POINTS_THRESHOLD = 100` - Minimum HN points to post
+- `HN_COMMENTS_THRESHOLD = 10` - Minimum HN comments to post
+- `DUPLICATE_CHECK_HOURS = 48` - Hours to look back for duplicates
+- `RSS_COUNT = 50` - Number of RSS items to fetch
+
+## URL Normalization
+
+The bot normalizes URLs to detect duplicates across different URL formats:
+- Strips `www.` prefix, normalizes to HTTPS
+- Reddit URLs are normalized to their post ID (e.g., `reddit.com/comments/1mau7yl`)
+- Query parameters and fragments are stripped for comparison
+
+## CI/CD
+
+### Go Version
+GitHub Actions workflow (`.github/workflows/run.yml`) runs the bot every 15 minutes via cron schedule.
+
+### Devvit Version
+No CI/CD needed - the bot runs on Reddit's infrastructure with a built-in scheduler.

--- a/devvit/README.md
+++ b/devvit/README.md
@@ -1,0 +1,161 @@
+# HN Bot - Devvit Version
+
+This is a port of the original Go bot to [Reddit's Developer Platform (Devvit)](https://developers.reddit.com). It maintains the same logic, function names, and coding style as the original.
+
+## Why Devvit?
+
+After Reddit's API changes in 2023, traditional bots using the old API face restrictions. Devvit is Reddit's official developer platform that:
+
+- Provides guaranteed API access for approved apps
+- Hosts your bot on Reddit's infrastructure (no external hosting needed)
+- Includes built-in scheduling (no GitHub Actions or cron required)
+- Handles authentication automatically
+
+## Prerequisites
+
+- Node.js 22.2.0 or later
+- A Reddit account
+- Moderator access to r/hackernews (or a test subreddit)
+
+## Setup
+
+### 1. Install Dependencies
+
+```bash
+cd devvit
+npm install
+```
+
+### 2. Install Devvit CLI
+
+```bash
+npm install -g devvit
+```
+
+### 3. Login to Reddit
+
+```bash
+devvit login
+```
+
+This will open a browser window for Reddit OAuth authentication.
+
+## Testing
+
+### Local Playtest
+
+Test the bot on a subreddit without deploying:
+
+```bash
+devvit playtest r/your-test-subreddit
+```
+
+This runs the app locally while connected to Reddit. You can trigger the bot manually using the "Run HN Bot Now" menu item in the subreddit's mod menu.
+
+### View Logs
+
+During playtest, logs appear in your terminal. After deployment, view logs with:
+
+```bash
+devvit logs r/hackernews
+```
+
+## Deployment
+
+### 1. Upload the App
+
+```bash
+devvit upload
+```
+
+This uploads your app to Reddit's servers.
+
+### 2. Install on Subreddit
+
+```bash
+devvit install r/hackernews
+```
+
+After installation, the bot will automatically:
+- Schedule itself to run every 15 minutes
+- Start posting HN stories that meet the threshold (100+ points, 10+ comments)
+
+## Project Structure
+
+```
+devvit/
+├── devvit.yaml          # App configuration
+├── package.json         # Dependencies
+├── tsconfig.json        # TypeScript config
+└── src/
+    ├── main.ts          # Entry point, Devvit setup, triggers
+    ├── constants.ts     # Configuration (thresholds, intervals)
+    ├── types.ts         # TypeScript interfaces
+    ├── url.ts           # URL normalization (same as Go version)
+    ├── duplicate.ts     # Duplicate detection (same as Go version)
+    ├── feed.ts          # RSS fetching from hnrss.org
+    ├── posts.ts         # Reddit post/comment operations
+    └── scheduler.ts     # Feed processing and scheduled job
+```
+
+## Function Mapping (Go → TypeScript)
+
+| Go Function | TypeScript Location |
+|-------------|---------------------|
+| `normalizeURL()` | `url.ts` |
+| `normalizeRedditURL()` | `url.ts` |
+| `buildFeedUrl()` | `feed.ts` |
+| `getFeed()` | `feed.ts` |
+| `isDuplicate()` | `duplicate.ts` |
+| `isSimilarTitle()` | `duplicate.ts` |
+| `getExistingPosts()` | `posts.ts` |
+| `postNew()` | `posts.ts` |
+| `processFeed()` | `scheduler.ts` |
+| `main()` | `scheduler.ts` (onRun handler) |
+| `newBot()` | N/A (Devvit handles auth) |
+
+## Configuration
+
+All constants are in `src/constants.ts` with the same names as the Go version:
+
+- `HN_POINTS_THRESHOLD = 100`
+- `HN_COMMENTS_THRESHOLD = 10`
+- `DUPLICATE_CHECK_HOURS = 48`
+- `RSS_COUNT = 50`
+- `SCHEDULER_CRON = "*/15 * * * *"`
+
+## Manual Trigger
+
+After installation, you can manually trigger the bot:
+
+1. Go to r/hackernews
+2. Click the mod menu (shield icon)
+3. Select "Run HN Bot Now"
+
+## Troubleshooting
+
+### App not running?
+
+Check if the scheduled job is registered:
+```bash
+devvit logs r/hackernews --since 1h
+```
+
+### Permission errors?
+
+Ensure the app has the required permissions by reinstalling:
+```bash
+devvit uninstall r/hackernews
+devvit install r/hackernews
+```
+
+### Rate limiting?
+
+The bot includes a 2-second delay between posts (same as the Go version). If you're still hitting limits, Reddit's platform handles backoff automatically.
+
+## Differences from Go Version
+
+1. **No environment variables** - Devvit handles authentication
+2. **Built-in scheduler** - No GitHub Actions needed
+3. **RSS parsing** - Uses simple regex parser instead of gofeed (works fine for hnrss.org's clean XML)
+4. **Hosting** - Runs on Reddit's servers, not yours

--- a/devvit/devvit.yaml
+++ b/devvit/devvit.yaml
@@ -1,0 +1,2 @@
+name: hn-bot
+version: 0.0.1

--- a/devvit/devvit.yaml
+++ b/devvit/devvit.yaml
@@ -1,2 +1,2 @@
-name: hn-bot
+name: hnbot-tstest-1
 version: 0.0.1

--- a/devvit/package.json
+++ b/devvit/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "hn-bot",
+  "version": "0.0.1",
+  "type": "module",
+  "private": true,
+  "license": "MIT",
+  "main": "src/main.ts",
+  "devDependencies": {
+    "@devvit/public-api": "0.11.12"
+  },
+  "engines": {
+    "node": ">=22.2.0"
+  }
+}

--- a/devvit/package.json
+++ b/devvit/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "hn-bot",
-  "version": "0.0.1",
+  "name": "hnbot-tstest-1",
+  "version": "0.0.0",
   "type": "module",
   "private": true,
-  "license": "MIT",
+  "license": "BSD-3-Clause",
   "main": "src/main.ts",
   "devDependencies": {
-    "@devvit/public-api": "0.11.12"
+    "@devvit/public-api": "0.12.6"
   },
   "engines": {
     "node": ">=22.2.0"

--- a/devvit/src/constants.ts
+++ b/devvit/src/constants.ts
@@ -1,0 +1,13 @@
+export const REDDIT_SUBREDDIT = "hackernews";
+export const HN_BASE_URL = "news.ycombinator.com";
+export const RSS_PROTOCOL = "https";
+export const RSS_BASE_URL = "hnrss.org";
+export const RSS_FEED = "frontpage";
+export const RSS_COUNT = 50;
+export const HN_POINTS_THRESHOLD = 100;
+export const HN_COMMENTS_THRESHOLD = 10;
+export const DUPLICATE_CHECK_HOURS = 48;
+export const SCHEDULER_JOB_NAME = "hnBotFeedProcessor";
+export const SCHEDULER_CRON = "*/15 * * * *";
+export const MAX_ERROR_COUNT = 3;
+export const POST_DELAY_MS = 2000;

--- a/devvit/src/duplicate.ts
+++ b/devvit/src/duplicate.ts
@@ -1,0 +1,66 @@
+import { RedditPost } from "./types.js";
+import { normalizeURL } from "./url.js";
+
+export function isDuplicate(
+  normalizedURL: string,
+  title: string,
+  existingPosts: RedditPost[],
+  cutoffTime: Date
+): boolean {
+  const titleLower = title.toLowerCase();
+
+  for (const post of existingPosts) {
+    if (post.createdAt < cutoffTime) {
+      continue;
+    }
+
+    const normalizedExisting = normalizeURL(post.url);
+    if (normalizedExisting === normalizedURL) {
+      return true;
+    }
+
+    if (isSimilarTitle(titleLower, post.title.toLowerCase())) {
+      console.log(`Similar title found: '${title}' vs '${post.title}'`);
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function isSimilarTitle(title1: string, title2: string): boolean {
+  if (title1 === title2) {
+    return true;
+  }
+
+  if (title1.includes(title2) || title2.includes(title1)) {
+    return true;
+  }
+
+  const words1 = title1.split(/\s+/);
+  const words2 = title2.split(/\s+/);
+
+  if (words1.length >= 4 && words2.length >= 4) {
+    let commonWords = 0;
+    const wordSet = new Set<string>();
+
+    for (const w of words1) {
+      if (w.length > 2) {
+        wordSet.add(w);
+      }
+    }
+
+    for (const w of words2) {
+      if (w.length > 2 && wordSet.has(w)) {
+        commonWords++;
+      }
+    }
+
+    const minWords = Math.min(words1.length, words2.length);
+    if (minWords > 0 && commonWords / minWords > 0.7) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/devvit/src/feed.ts
+++ b/devvit/src/feed.ts
@@ -1,0 +1,97 @@
+import { Feed, FeedItem } from "./types.js";
+import {
+  RSS_PROTOCOL,
+  RSS_BASE_URL,
+  RSS_FEED,
+  RSS_COUNT,
+  HN_POINTS_THRESHOLD,
+  HN_COMMENTS_THRESHOLD,
+} from "./constants.js";
+
+export function buildFeedUrl(): string {
+  const params = new URLSearchParams({
+    count: RSS_COUNT.toString(),
+    points: HN_POINTS_THRESHOLD.toString(),
+    comments: HN_COMMENTS_THRESHOLD.toString(),
+  });
+
+  return `${RSS_PROTOCOL}://${RSS_BASE_URL}/${RSS_FEED}?${params.toString()}`;
+}
+
+export async function getFeed(): Promise<Feed> {
+  console.log("Getting feed");
+
+  const rssURL = buildFeedUrl();
+  console.log("RSS URL:", rssURL);
+
+  const response = await fetch(rssURL);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch RSS feed: ${response.status}`);
+  }
+
+  const xmlText = await response.text();
+  const feed = parseRSSFeed(xmlText);
+
+  if (!feed) {
+    throw new Error("Feed is nil after parsing");
+  }
+
+  if (!feed.items || feed.items.length === 0) {
+    throw new Error("Feed items are empty");
+  }
+
+  for (let i = 0; i < feed.items.length; i++) {
+    const item = feed.items[i];
+    if (!item) {
+      throw new Error(`Feed item at index ${i} is nil`);
+    }
+    if (!item.publishedParsed) {
+      throw new Error(`Feed item at index ${i} has nil publish date`);
+    }
+  }
+
+  return feed;
+}
+
+function parseRSSFeed(xmlText: string): Feed {
+  const items: FeedItem[] = [];
+
+  const itemRegex = /<item>([\s\S]*?)<\/item>/g;
+  let match;
+
+  while ((match = itemRegex.exec(xmlText)) !== null) {
+    const itemXml = match[1];
+
+    const title = extractTag(itemXml, "title");
+    const link = extractTag(itemXml, "link");
+    const guid = extractTag(itemXml, "guid");
+    const pubDate = extractTag(itemXml, "pubDate");
+
+    items.push({
+      title: title || "",
+      link: link || "",
+      guid: guid || "",
+      publishedParsed: pubDate ? new Date(pubDate) : null,
+    });
+  }
+
+  return { items };
+}
+
+function extractTag(xml: string, tagName: string): string | null {
+  const cdataRegex = new RegExp(
+    `<${tagName}[^>]*><!\\[CDATA\\[([\\s\\S]*?)\\]\\]></${tagName}>`
+  );
+  const cdataMatch = xml.match(cdataRegex);
+  if (cdataMatch) {
+    return cdataMatch[1].trim();
+  }
+
+  const plainRegex = new RegExp(`<${tagName}[^>]*>([\\s\\S]*?)</${tagName}>`);
+  const plainMatch = xml.match(plainRegex);
+  if (plainMatch) {
+    return plainMatch[1].trim();
+  }
+
+  return null;
+}

--- a/devvit/src/main.ts
+++ b/devvit/src/main.ts
@@ -1,0 +1,45 @@
+import { Devvit } from "@devvit/public-api";
+import {
+  SCHEDULER_JOB_NAME,
+  SCHEDULER_CRON,
+  REDDIT_SUBREDDIT,
+} from "./constants.js";
+import { registerSchedulerJob } from "./scheduler.js";
+
+Devvit.configure({
+  redditAPI: true,
+  http: true,
+});
+
+registerSchedulerJob();
+
+Devvit.addTrigger({
+  event: "AppInstall",
+  onEvent: async (_event, context) => {
+    console.log(`HN Bot installed on r/${REDDIT_SUBREDDIT}`);
+
+    await context.scheduler.runJob({
+      name: SCHEDULER_JOB_NAME,
+      cron: SCHEDULER_CRON,
+    });
+
+    console.log("Scheduled recurring job with cron:", SCHEDULER_CRON);
+  },
+});
+
+Devvit.addMenuItem({
+  label: "Run HN Bot Now",
+  location: "subreddit",
+  onPress: async (_event, context) => {
+    console.log("Manual trigger requested");
+
+    await context.scheduler.runJob({
+      name: SCHEDULER_JOB_NAME,
+      runAt: new Date(),
+    });
+
+    context.ui.showToast("HN Bot job triggered");
+  },
+});
+
+export default Devvit;

--- a/devvit/src/main.ts
+++ b/devvit/src/main.ts
@@ -5,6 +5,7 @@ import {
   REDDIT_SUBREDDIT,
 } from "./constants.js";
 import { registerSchedulerJob } from "./scheduler.js";
+import { getFeed } from "./feed.js";
 
 Devvit.configure({
   redditAPI: true,
@@ -39,6 +40,34 @@ Devvit.addMenuItem({
     });
 
     context.ui.showToast("HN Bot job triggered");
+  },
+});
+
+// Dry-run test: only fetches RSS feed, doesn't post anything
+Devvit.addMenuItem({
+  label: "Test HN Feed Fetch (Dry Run)",
+  location: "subreddit",
+  onPress: async (_event, context) => {
+    console.log("=== DRY RUN TEST START ===");
+    console.log("Testing fetch to hnrss.org...");
+
+    try {
+      const feed = await getFeed();
+      console.log(`SUCCESS: Fetched ${feed.items.length} items from hnrss.org`);
+      console.log("First 3 items:");
+      for (let i = 0; i < Math.min(3, feed.items.length); i++) {
+        const item = feed.items[i];
+        console.log(`  ${i + 1}. ${item.title}`);
+        console.log(`     Link: ${item.link}`);
+        console.log(`     HN: ${item.guid}`);
+      }
+      context.ui.showToast(`Success! Fetched ${feed.items.length} items from hnrss.org`);
+    } catch (err) {
+      console.error("FAILED to fetch from hnrss.org:", err);
+      context.ui.showToast(`Failed: ${err}`);
+    }
+
+    console.log("=== DRY RUN TEST END ===");
   },
 });
 

--- a/devvit/src/posts.ts
+++ b/devvit/src/posts.ts
@@ -1,4 +1,4 @@
-import { Devvit } from "@devvit/public-api";
+import { Devvit, Subreddit } from "@devvit/public-api";
 import { RedditPost, FeedItem } from "./types.js";
 import { REDDIT_SUBREDDIT, HN_BASE_URL } from "./constants.js";
 import { normalizeURL } from "./url.js";
@@ -75,6 +75,7 @@ export async function getExistingPosts(
 
 export async function postNew(
   context: Devvit.Context,
+  subreddit: Subreddit,
   item: FeedItem,
   existingPosts: RedditPost[],
   cutoffTime: Date
@@ -99,7 +100,6 @@ export async function postNew(
     return;
   }
 
-  const subreddit = await context.reddit.getSubredditByName(REDDIT_SUBREDDIT);
   const submission = await subreddit.submitPost({
     title: item.title,
     url: item.link,

--- a/devvit/src/posts.ts
+++ b/devvit/src/posts.ts
@@ -1,0 +1,143 @@
+import { Devvit } from "@devvit/public-api";
+import { RedditPost, FeedItem } from "./types.js";
+import { REDDIT_SUBREDDIT, HN_BASE_URL } from "./constants.js";
+import { normalizeURL } from "./url.js";
+import { isDuplicate } from "./duplicate.js";
+
+export async function getExistingPosts(
+  context: Devvit.Context
+): Promise<RedditPost[]> {
+  console.log("Getting existing posts from subreddit");
+
+  const allPosts: RedditPost[] = [];
+  let lastErr: Error | null = null;
+  let successCount = 0;
+
+  const pageTypes = ["new", "hot", "top"] as const;
+
+  for (const pageType of pageTypes) {
+    try {
+      let posts;
+
+      if (pageType === "new") {
+        posts = await context.reddit
+          .getNewPosts({
+            subredditName: REDDIT_SUBREDDIT,
+            limit: 100,
+          })
+          .all();
+      } else if (pageType === "hot") {
+        posts = await context.reddit
+          .getHotPosts({
+            subredditName: REDDIT_SUBREDDIT,
+            limit: 100,
+          })
+          .all();
+      } else {
+        posts = await context.reddit
+          .getTopPosts({
+            subredditName: REDDIT_SUBREDDIT,
+            timeframe: "week",
+            limit: 100,
+          })
+          .all();
+      }
+
+      successCount++;
+
+      for (const post of posts) {
+        if (post.url && !post.removed) {
+          allPosts.push({
+            url: post.url,
+            title: post.title,
+            createdAt: post.createdAt,
+          });
+        }
+      }
+    } catch (err) {
+      console.log(`Warning: failed to get ${pageType} listings: ${err}`);
+      lastErr = err as Error;
+    }
+  }
+
+  if (successCount === 0) {
+    throw new Error(`Failed to fetch any listings: ${lastErr?.message}`);
+  }
+
+  if (allPosts.length === 0) {
+    console.log("No existing posts found");
+  } else {
+    console.log(`Found ${allPosts.length} existing posts across new/hot/top`);
+  }
+
+  return allPosts;
+}
+
+export async function postNew(
+  context: Devvit.Context,
+  item: FeedItem,
+  existingPosts: RedditPost[],
+  cutoffTime: Date
+): Promise<void> {
+  if (!item.title) {
+    throw new Error("Item title is empty");
+  }
+
+  if (!item.link) {
+    throw new Error("Item link is empty");
+  }
+
+  console.log("Posting:", item.title);
+
+  const isHn = item.link.includes(HN_BASE_URL);
+  console.log("HN link:", isHn);
+
+  const normalizedLink = normalizeURL(item.link);
+
+  if (isDuplicate(normalizedLink, item.title, existingPosts, cutoffTime)) {
+    console.log("Post already exists (double-check), skipping:", item.link);
+    return;
+  }
+
+  const subreddit = await context.reddit.getSubredditByName(REDDIT_SUBREDDIT);
+  const submission = await subreddit.submitPost({
+    title: item.title,
+    url: item.link,
+  });
+
+  if (!submission.id) {
+    throw new Error("No post id returned");
+  }
+
+  existingPosts.push({
+    url: item.link,
+    title: item.title,
+    createdAt: new Date(),
+  });
+
+  if (isHn) {
+    return;
+  }
+
+  const hnLink = item.guid;
+  if (!hnLink) {
+    console.log(
+      `Warning: no HN link found in GUID for '${item.title}', skipping comment`
+    );
+    return;
+  }
+
+  if (!hnLink.includes(HN_BASE_URL)) {
+    console.log(
+      `Warning: GUID is not an HN link for '${item.title}': ${hnLink}, skipping comment`
+    );
+    return;
+  }
+
+  const commentTxt = "Discussion on HN: " + hnLink;
+  const reply = await submission.addComment({ text: commentTxt });
+
+  if (!reply.id) {
+    throw new Error("No comment id returned");
+  }
+}

--- a/devvit/src/scheduler.ts
+++ b/devvit/src/scheduler.ts
@@ -4,6 +4,7 @@ import {
   DUPLICATE_CHECK_HOURS,
   MAX_ERROR_COUNT,
   POST_DELAY_MS,
+  REDDIT_SUBREDDIT,
   SCHEDULER_JOB_NAME,
 } from "./constants.js";
 import { normalizeURL } from "./url.js";
@@ -24,6 +25,7 @@ export async function processFeed(
   let errorCount = 0;
 
   const existingPosts = await getExistingPosts(context);
+  const subreddit = await context.reddit.getSubredditByName(REDDIT_SUBREDDIT);
 
   const cutoffTime = new Date(
     Date.now() - DUPLICATE_CHECK_HOURS * 60 * 60 * 1000
@@ -57,7 +59,7 @@ export async function processFeed(
     }
 
     try {
-      await postNew(context, item, existingPosts, cutoffTime);
+      await postNew(context, subreddit, item, existingPosts, cutoffTime);
       processedCount++;
       await sleep(POST_DELAY_MS);
     } catch (err) {

--- a/devvit/src/scheduler.ts
+++ b/devvit/src/scheduler.ts
@@ -1,0 +1,97 @@
+import { Devvit } from "@devvit/public-api";
+import { Feed } from "./types.js";
+import {
+  DUPLICATE_CHECK_HOURS,
+  MAX_ERROR_COUNT,
+  POST_DELAY_MS,
+  SCHEDULER_JOB_NAME,
+} from "./constants.js";
+import { normalizeURL } from "./url.js";
+import { isDuplicate } from "./duplicate.js";
+import { getFeed } from "./feed.js";
+import { getExistingPosts, postNew } from "./posts.js";
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function processFeed(
+  context: Devvit.Context,
+  feed: Feed
+): Promise<void> {
+  console.log("Processing feed");
+  let processedCount = 0;
+  let errorCount = 0;
+
+  const existingPosts = await getExistingPosts(context);
+
+  const cutoffTime = new Date(
+    Date.now() - DUPLICATE_CHECK_HOURS * 60 * 60 * 1000
+  );
+
+  for (let i = 0; i < feed.items.length; i++) {
+    const item = feed.items[i];
+
+    if (!item) {
+      console.log(`Warning: skipping nil item at index ${i}`);
+      continue;
+    }
+
+    if (!item.publishedParsed) {
+      console.log(
+        `Warning: skipping item with nil publish date: ${item.title}`
+      );
+      continue;
+    }
+
+    if (!item.link) {
+      console.log(`Warning: skipping item with empty link: ${item.title}`);
+      continue;
+    }
+
+    const normalizedLink = normalizeURL(item.link);
+
+    if (isDuplicate(normalizedLink, item.title, existingPosts, cutoffTime)) {
+      console.log(`Post already exists, skipping: ${item.link}`);
+      continue;
+    }
+
+    try {
+      await postNew(context, item, existingPosts, cutoffTime);
+      processedCount++;
+      await sleep(POST_DELAY_MS);
+    } catch (err) {
+      errorCount++;
+      console.log(`Error posting item ${i} (${item.title}): ${err}`);
+      if (errorCount >= MAX_ERROR_COUNT) {
+        throw new Error(`Too many posting errors (${errorCount}): aborting`);
+      }
+    }
+  }
+
+  console.log(`Successfully processed ${processedCount} items`);
+}
+
+export function registerSchedulerJob(): void {
+  Devvit.addSchedulerJob({
+    name: SCHEDULER_JOB_NAME,
+    onRun: async (_event, context) => {
+      console.log("Starting");
+
+      try {
+        const feed = await getFeed();
+
+        if (!feed) {
+          throw new Error("Error: feed is nil");
+        }
+
+        await processFeed(context, feed);
+
+        console.log("Done");
+      } catch (err) {
+        console.error("Bot run failed:", err);
+        throw err;
+      }
+    },
+  });
+}

--- a/devvit/src/types.ts
+++ b/devvit/src/types.ts
@@ -1,0 +1,16 @@
+export interface RedditPost {
+  url: string;
+  title: string;
+  createdAt: Date;
+}
+
+export interface FeedItem {
+  title: string;
+  link: string;
+  guid: string;
+  publishedParsed: Date | null;
+}
+
+export interface Feed {
+  items: FeedItem[];
+}

--- a/devvit/src/url.ts
+++ b/devvit/src/url.ts
@@ -1,0 +1,66 @@
+export function normalizeURL(rawURL: string): string {
+  if (!rawURL) {
+    return rawURL;
+  }
+
+  if (rawURL.includes("reddit.com") || rawURL.includes("redd.it")) {
+    return normalizeRedditURL(rawURL);
+  }
+
+  let parsedURL: URL;
+  try {
+    parsedURL = new URL(rawURL);
+  } catch {
+    return rawURL;
+  }
+
+  parsedURL.protocol = parsedURL.protocol.toLowerCase();
+  parsedURL.hostname = parsedURL.hostname.toLowerCase();
+
+  if (parsedURL.protocol === "" || parsedURL.protocol === "http:") {
+    parsedURL.protocol = "https:";
+  }
+
+  if (parsedURL.hostname.startsWith("www.")) {
+    parsedURL.hostname = parsedURL.hostname.slice(4);
+  }
+
+  let path = parsedURL.pathname.replace(/\/$/, "");
+  if (path === "") {
+    path = "/";
+  }
+  parsedURL.pathname = path;
+
+  parsedURL.hash = "";
+  parsedURL.search = "";
+
+  return parsedURL.toString();
+}
+
+export function normalizeRedditURL(rawURL: string): string {
+  if (!rawURL) {
+    return rawURL;
+  }
+
+  let cleanURL = rawURL;
+  const queryIndex = cleanURL.indexOf("?");
+  if (queryIndex !== -1) {
+    cleanURL = cleanURL.slice(0, queryIndex);
+  }
+
+  const redditIDRegex = /(?:reddit\.com\/r\/[^/]+\/comments\/|redd\.it\/)([a-zA-Z0-9]+)/;
+  const matches = cleanURL.match(redditIDRegex);
+  if (matches && matches[1]) {
+    return "reddit.com/comments/" + matches[1];
+  }
+
+  if (cleanURL.includes("/s/")) {
+    const shareIDRegex = /\/s\/([a-zA-Z0-9]+)/;
+    const shareMatches = cleanURL.match(shareIDRegex);
+    if (shareMatches && shareMatches[1]) {
+      return "reddit.com/s/" + shareMatches[1];
+    }
+  }
+
+  return cleanURL;
+}

--- a/devvit/tsconfig.json
+++ b/devvit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
With the best intentions, I took the chance to try to port your hnbot from Go to TypeScript for the Devvit platform, with the help of Claude Code. Feel free to discard it or give it a try.

The Devvit version:
- Maintains the same logic, function names, and coding style
- Uses built-in scheduler (no GitHub Actions needed)
- Runs on Reddit's infrastructure (no external hosting)
- Handles authentication automatically through the platform

Files added:
- devvit/src/*.ts - TypeScript port of all Go functions
- devvit/README.md - Setup and deployment instructions
- CLAUDE.md - Project documentation for AI assistants

Hope this helps!